### PR TITLE
add placeholder image when image missing in product catalogue

### DIFF
--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -50,7 +50,7 @@ class Item extends React.Component {
           <div className="row bg-white p-4">
             <div className="col-6">
               <img
-                src={this.props.item.image}
+                src={this.props.item.image ? this.props.item.image : "/placeholder.png"}
                 alt={this.props.item.title}
                 className="item-img"
                 style={{ height: "500px", width: "100%", borderRadius: "6px" }}

--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -50,7 +50,7 @@ class Item extends React.Component {
           <div className="row bg-white p-4">
             <div className="col-6">
               <img
-                src={this.props.item.image ? this.props.item.image : "/placeholder.png"}
+                src={this.props.item.image}
                 alt={this.props.item.title}
                 className="item-img"
                 style={{ height: "500px", width: "100%", borderRadius: "6px" }}

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -36,7 +36,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image ? item.image : "/placeholder.png"}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
# Description

Added **placeholder.png** for when the image URL is missing for an item in the **product catalogue**.
Fixes #2 

Here's what it looks like now:
![image-bug-fix](https://user-images.githubusercontent.com/54367435/185786720-fdd095b9-49fd-43b5-8c9c-7a389caa10a7.png)

